### PR TITLE
US247 Reset Model List

### DIFF
--- a/client/src/components/Models/index.vue
+++ b/client/src/components/Models/index.vue
@@ -11,7 +11,16 @@
           the state held on the server and the state in the browser.
           <md-button @click="restart" class="md-accent">Restart</md-button>
           -->
-          <md-button @click="create" class="md-primary">New Model</md-button>
+          <md-button @click="create" class="md-icon-button">
+            <md-icon>add</md-icon>
+            <md-tooltip>New Model</md-tooltip>
+          </md-button>
+          <md-button @click="showDeleteAllDialog = true"
+            v-if="STORE_STATE.modelNames.length > 0"
+            class="md-icon-button">
+            <md-icon>delete_forever</md-icon>
+            <md-tooltip>Delete All</md-tooltip>
+          </md-button>
         </div>
       </div>
       <md-list v-if="STORE_STATE.modelNames.length > 0" class="model-list">
@@ -29,6 +38,19 @@
         />
       </md-list>
       <p v-else>No models created yet. Please click "New Model"</p>
+      <md-dialog
+        :md-active.sync="showDeleteAllDialog"
+        :md-close-on-esc="false"
+        :md-click-outside-to-close="false">
+        <md-dialog-title>Confirm Delete All</md-dialog-title>
+        <md-dialog-content>
+          Are you sure you want to delete all of your models and start from scratch?
+        </md-dialog-content>
+        <md-dialog-actions>
+          <md-button @click="deleteAll">Delete Everything</md-button>
+          <md-button @click="showDeleteAllDialog = false">Cancel</md-button>
+        </md-dialog-actions>
+      </md-dialog>
     </md-toolbar>
     <div v-if="loading"
       style="display: grid; height: 100%">
@@ -54,6 +76,7 @@ export default {
     return {
       loading: false,
       blocked: false,
+      showDeleteAllDialog: false,
 
       /**
        * Needs to stay as a direct reference to the state of the store so that
@@ -91,6 +114,10 @@ export default {
     },
     edit(modelName) {
       this.$router.push(`/edit/${modelName}`);
+    },
+    async deleteAll() {
+      await this.$store.clearModels();
+      this.showDeleteAllDialog = false;
     },
     async copy(modelName) {
       this.loading = true;

--- a/client/src/utils/Store.js
+++ b/client/src/utils/Store.js
@@ -222,6 +222,7 @@ export default class API {
       await clear();
       this.state.models = {};
       this.state.modelNames = this.getModelNames();
+      await this.getPlotData();
     } catch (error) {
       console.log(error);
     }

--- a/client/src/utils/Store.js
+++ b/client/src/utils/Store.js
@@ -7,6 +7,7 @@ import {
   keys,
   del,
   get,
+  clear,
 } from 'idb-keyval';
 
 axios.defaults.withCredentials = true;
@@ -208,6 +209,21 @@ export default class API {
       await this.getPlotData();
     } catch (error) {
       console.error(error);
+    }
+  }
+
+  /**
+   * Clears all existing models
+   * @returns {void}
+   */
+  clearModels = async () => {
+    try {
+      await axios.post(`${baseurl}/clear`);
+      await clear();
+      this.state.models = {};
+      this.state.modelNames = this.getModelNames();
+    } catch (error) {
+      console.log(error);
     }
   }
 

--- a/client/tests/mockServer.js
+++ b/client/tests/mockServer.js
@@ -1,8 +1,8 @@
 import { createServer, Model } from 'miragejs';
 import baseurl from '@/env';
+// import { schemeAccent } from 'd3';
 import plotData from './example_data/plotData.json';
 import plotTypes from './example_data/plotTypes.json';
-import { schemeAccent } from 'd3';
 
 /**
  * Creates a mock server for use in tests on the front-end.
@@ -59,7 +59,6 @@ export default function makeServer(environment) {
         const newModelName = request.requestBody.new_model_name;
         return schema.haloModels.create(newModelName);
       });
-      
 
       this.post(`${baseurl}/rename`, (schema, request) => {
         const newModelName = request.requestBody.new_model_name;
@@ -73,9 +72,7 @@ export default function makeServer(environment) {
         return schema.haloModels.findBy({ name: modelName }).destroy();
       });
 
-      this.post(`${baseurl}/clear`, (schema, _request) => {
-        return schema.haloModels.all().destroy();
-      })
+      this.post(`${baseurl}/clear`, (schema) => schema.haloModels.all().destroy());
 
       this.get(`${baseurl}/get_plot_types`, () => plotTypes);
     },

--- a/client/tests/mockServer.js
+++ b/client/tests/mockServer.js
@@ -2,6 +2,7 @@ import { createServer, Model } from 'miragejs';
 import baseurl from '@/env';
 import plotData from './example_data/plotData.json';
 import plotTypes from './example_data/plotTypes.json';
+import { schemeAccent } from 'd3';
 
 /**
  * Creates a mock server for use in tests on the front-end.
@@ -58,6 +59,7 @@ export default function makeServer(environment) {
         const newModelName = request.requestBody.new_model_name;
         return schema.haloModels.create(newModelName);
       });
+      
 
       this.post(`${baseurl}/rename`, (schema, request) => {
         const newModelName = request.requestBody.new_model_name;
@@ -70,6 +72,10 @@ export default function makeServer(environment) {
         const modelName = request.requestBody.model_name;
         return schema.haloModels.findBy({ name: modelName }).destroy();
       });
+
+      this.post(`${baseurl}/clear`, (schema, _request) => {
+        return schema.haloModels.all().destroy();
+      })
 
       this.get(`${baseurl}/get_plot_types`, () => plotTypes);
     },

--- a/client/tests/unit/Store.spec.js
+++ b/client/tests/unit/Store.spec.js
@@ -79,11 +79,10 @@ describe('Store tests', () => {
     expect(store.getModelNames()).toContain(newModelName);
   });
 
-
   test('Clearing models should remove all existing models', async () => {
-    await store.createModel(DEFAULT_MODEL, "MyModel");
-    await store.createModel(DEFAULT_MODEL, "AnotherModel");
-    await store.createModel(DEFAULT_MODEL, "AndAnotherOne");
+    await store.createModel(DEFAULT_MODEL, 'MyModel');
+    await store.createModel(DEFAULT_MODEL, 'AnotherModel');
+    await store.createModel(DEFAULT_MODEL, 'AndAnotherOne');
     expect(store.getModelNames()).toHaveLength(3);
     await store.clearModels();
     expect(store.getModelNames()).toHaveLength(0);

--- a/client/tests/unit/Store.spec.js
+++ b/client/tests/unit/Store.spec.js
@@ -79,6 +79,16 @@ describe('Store tests', () => {
     expect(store.getModelNames()).toContain(newModelName);
   });
 
+
+  test('Clearing models should remove all existing models', async () => {
+    await store.createModel(DEFAULT_MODEL, "MyModel");
+    await store.createModel(DEFAULT_MODEL, "AnotherModel");
+    await store.createModel(DEFAULT_MODEL, "AndAnotherOne");
+    expect(store.getModelNames()).toHaveLength(3);
+    await store.clearModels();
+    expect(store.getModelNames()).toHaveLength(0);
+  });
+
   test('Changing the plot type should reflect in state', async () => {
     const newPlotType = 'somePlotType';
     await store.setPlotType(newPlotType);

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -7565,6 +7565,11 @@ lodash.compact@^3.0.1:
   resolved "https://registry.yarnpkg.com/lodash.compact/-/lodash.compact-3.0.1.tgz#540ce3837745975807471e16b4a2ba21e7256ca5"
   integrity sha1-VAzjg3dFl1gHRx4WtKK6IeclbKU=
 
+lodash.debounce@^4.0.8:
+  version "4.0.8"
+  resolved "https://registry.yarnpkg.com/lodash.debounce/-/lodash.debounce-4.0.8.tgz#82d79bff30a67c4005ffd5e2515300ad9ca4d7af"
+  integrity sha1-gteb/zCmfEAF/9XiUVMArZyk168=
+
 lodash.defaultsdeep@^4.6.1:
   version "4.6.1"
   resolved "https://registry.yarnpkg.com/lodash.defaultsdeep/-/lodash.defaultsdeep-4.6.1.tgz#512e9bd721d272d94e3d3a63653fa17516741ca6"

--- a/server/halomod_app/__init__.py
+++ b/server/halomod_app/__init__.py
@@ -239,7 +239,7 @@ def create_app(test_config=None):
     # This endpoint clears all models from the session
     #
     # expects: None
-    # outputs: {"model_names": <list_of_model_names_in_session>} 
+    # outputs: {"model_names": <list_of_model_names_in_session>}
     @app.route('/clear', methods=["POST"])
     def clear():
         session["models"] = pickle.dumps({})

--- a/server/halomod_app/__init__.py
+++ b/server/halomod_app/__init__.py
@@ -236,6 +236,16 @@ def create_app(test_config=None):
         res = {"model_names": get_model_names()}
         return jsonify(res)
 
+    # This endpoint clears all models from the session
+    #
+    # expects: None
+    # outputs: {"model_names": <list_of_model_names_in_session>} 
+    @app.route('/clear', methods=["POST"])
+    def clear():
+        session["models"] = pickle.dumps({})
+        res = {"model_names": get_model_names()}
+        return jsonify(res)
+
     # Generates a figure using session data & matplotlib rendering and
     # returns it to client
     #

--- a/server/tests/test_halomod.py
+++ b/server/tests/test_halomod.py
@@ -84,6 +84,20 @@ def test_delete(client):
     assert "TheModel" not in names
 
 
+def test_clear(client):
+    with client.session_transaction() as sess:
+        sess["models"] = pickle.dumps({
+            "TheModel": TracerHaloModel(),
+            "AnotherModel": TracerHaloModel(),
+            "AndAnotherOne": TracerHaloModel()})
+    response = client.post('/clear')
+    assert response is not None
+    assert response.status_code == 200
+    assert "model_names" in response.json
+    names = response.json["model_names"]
+    assert not names
+
+
 def test_get_plot_data(client):
     with client.session_transaction() as sess:
         sess["models"] = pickle.dumps({"TheModel": TracerHaloModel()})


### PR DESCRIPTION
This pull request includes:
- a server endpoint that clears all models tied to the calling session
- a client store method that clears models stored in IDB, the store itself & requests a clear all on the server
- a UI element on the home page which lets the user perform this action
- a little change to the home page UI to use an icon button instead of 'Create Model'
Let me know if anything needs to be changed.
 
Developer Checklist:

- [X] The code follows the Quality Policy file on Google Drive
- [X] My code has been developer tested and includes unit tests
- [X] I have considered proper use of exceptions
- [X] I have eliminated IDE warnings
- [X] I have included tasks associated with this pull request in the Sprint Progress Sheet.