### PR TITLE
US279 T297 Tests for Basic GenericForm

### DIFF
--- a/client/jest.config.js
+++ b/client/jest.config.js
@@ -1,7 +1,7 @@
 module.exports = {
   preset: '@vue/cli-plugin-unit-jest',
   testPathIgnorePatterns: [
-    '<rootDir>/tests/unit/.*Form.spec.js',
+    '<rootDir>/tests/unit/(?!Generic).*Form.spec.js',
   ],
   moduleFileExtensions: ['js', 'json', 'vue'],
   transform: {

--- a/client/src/components/forms/index.vue
+++ b/client/src/components/forms/index.vue
@@ -6,7 +6,7 @@
       class="md-primary"
       md-fixed>
       <md-list>
-        <md-list-item v-for="(form, index) in forms" :key="index"
+        <md-list-item v-for="(form, index) in Object.values(forms)" :key="index"
           :class="{'router-link-active': currentlyVisible == form.title}"
           :to="`#${form.id}`">
           {{form.title}}
@@ -22,7 +22,7 @@
             <h2 class="md-title">{{contextSecondary}}</h2>
           </div>
           <md-divider/>
-          <div v-for="(form, index) in forms" :key="index">
+          <div v-for="(form, index) in Object.values(forms)" :key="index">
             <FormWrapper
               :id="form.id"
               :title="form.title"
@@ -104,7 +104,6 @@ export default {
       window.history.replaceState({}, '', `#${id}`);
     },
     buildProps(form) {
-      // console.log(this.default[form.id]);
       return { ...form.props, initial_data: this.default[form.id], title: form.title };
     },
   },

--- a/client/src/constants/forms.js
+++ b/client/src/constants/forms.js
@@ -14,14 +14,14 @@ import BACKEND_CONSTANTS from '@/constants/backend_constants.js';
 //    Description: Has core parameters with defined ranges, special styling, and/or special types
 //    Examples: Halo Model, Cosmology, Transfer,  Filter
 
-const FORMS = [
+const FORMS = {
   // {
   //   component: CosmologyForm,
   //   model: 'cosmo',
   //   title: 'Cosmology',
   //   id: 'cosmology',
   // },
-  {
+  mdef: {
     id: 'mdef',
     title: 'Mass Definition',
     props: {
@@ -43,7 +43,7 @@ const FORMS = [
   //   title: 'Filter',
   //   id: 'filter',
   // },
-  {
+  growth: {
     id: 'growth',
     title: 'Growth',
     props: {
@@ -65,7 +65,7 @@ const FORMS = [
   //   title: 'Halo Model',
   //   id: 'halo_model',
   // },
-  {
+  hod: {
     id: 'hod',
     title: 'HOD',
     props: {
@@ -75,7 +75,7 @@ const FORMS = [
       all_data: BACKEND_CONSTANTS.hod_params,
     },
   },
-  {
+  bias: {
     id: 'bias',
     title: 'Bias',
     props: {
@@ -85,7 +85,7 @@ const FORMS = [
       all_data: BACKEND_CONSTANTS.bias_params,
     },
   },
-  {
+  halo_concentration: {
     id: 'halo_concentration',
     title: 'Halo Concentration',
     props: {
@@ -95,7 +95,7 @@ const FORMS = [
       all_data: BACKEND_CONSTANTS.concentration_params,
     },
   },
-  {
+  tracer_concentration: {
     id: 'tracer_concentration',
     title: 'Tracer Concentration',
     props: {
@@ -105,7 +105,7 @@ const FORMS = [
       all_data: BACKEND_CONSTANTS.concentration_params,
     },
   },
-  {
+  halo_profile: {
     id: 'halo_profile',
     title: 'Halo Profile',
     props: {
@@ -115,7 +115,7 @@ const FORMS = [
       all_data: BACKEND_CONSTANTS.profile_params,
     },
   },
-  {
+  tracer_profile: {
     id: 'tracer_profile',
     title: 'Tracer Profile',
     props: {
@@ -125,7 +125,7 @@ const FORMS = [
       all_data: BACKEND_CONSTANTS.profile_params,
     },
   },
-  {
+  halo_exclusion: {
     id: 'halo_exclusion',
     title: 'Halo Exclusion',
     props: {
@@ -135,6 +135,6 @@ const FORMS = [
       all_data: BACKEND_CONSTANTS.exclusion_params,
     },
   },
-];
+};
 
 export default FORMS;

--- a/client/tests/unit/GenericForm.spec.js
+++ b/client/tests/unit/GenericForm.spec.js
@@ -1,0 +1,139 @@
+import GenericForm from '@/components/forms/GenericForm.vue';
+import { mount, createLocalVue } from '@vue/test-utils';
+import SUBFORMS from '@/constants/forms.js';
+import INITIAL_STATE from '@/constants/initial_state.json';
+import VueMaterial from 'vue-material';
+import clone from 'lodash.clonedeep';
+
+describe('Mounted GenericForm', () => {
+  const localVue = createLocalVue();
+  localVue.use(VueMaterial);
+
+  let wrapper;
+
+  beforeEach(() => {
+    wrapper = mount(GenericForm, {
+      localVue,
+      propsData: {
+        ...SUBFORMS.bias.props,
+        initial_data: INITIAL_STATE.bias,
+        title: SUBFORMS.bias.title,
+      },
+      stubs: {
+        'vue-observe-visibility': true,
+        'router-link': true,
+        'ejs-slider': true,
+      },
+    });
+  });
+
+  /**
+   * Core Vue Tests
+   */
+
+  test('initializes with correct data', () => {
+    expect(wrapper.vm.model).toEqual(wrapper.vm.initial_data);
+    expect(wrapper.vm.defaults).toEqual(wrapper.vm.initial_data);
+    expect(wrapper.vm.cache).toEqual(wrapper.vm.all_data);
+  });
+
+  test('correctly updates cache when model selection changes',
+    async () => {
+      wrapper.vm.model.bias_params.B = 0.184;
+      const initialState = wrapper.vm.model.bias_params;
+      await localVue.nextTick();
+      await localVue.nextTick();
+      wrapper.vm.model.bias_model = 'Tinker10PBSplit';
+      await localVue.nextTick();
+      await localVue.nextTick();
+      expect(wrapper.vm.cache.Tinker10).toEqual(initialState);
+    });
+
+  test('correctly updates available parameters when model selection changes',
+    async () => {
+      const initialState = wrapper.vm.model.bias_params;
+      wrapper.vm.model.bias_model = 'Tinker10PBSplit';
+      await localVue.nextTick();
+      await localVue.nextTick();
+      expect(wrapper.vm.model.bias_params).not.toEqual(initialState);
+    });
+
+  test('emits onChange event whenever model selection or params changed',
+    async () => {
+      const emitted = wrapper.emitted();
+      let prevCount = 0;
+      wrapper.vm.model.bias_params.B = 0.184;
+      await localVue.nextTick();
+      await localVue.nextTick();
+      expect(emitted.onChange.length).toBeGreaterThan(prevCount);
+      prevCount = emitted.onChange.length;
+      wrapper.vm.model.bias_model = 'Tinker10PBSplit';
+      await localVue.nextTick();
+      await localVue.nextTick();
+      expect(emitted.onChange.length).toBeGreaterThan(prevCount);
+    });
+
+  test('properly updates model, defaults and cache when initial_state prop changes',
+    async () => {
+      wrapper.vm.model.bias_params.B = 1;
+      wrapper.vm.model.bias_model = 'Tinker10PBSplit';
+      await localVue.nextTick();
+      await localVue.nextTick();
+      const initialModel = wrapper.vm.model;
+      const initialDefaults = wrapper.vm.defaults;
+      const initialCache = wrapper.vm.cache;
+      wrapper.setProps({
+        ...wrapper.vm.propsData,
+        initial_data: clone(INITIAL_STATE.bias),
+      });
+      await localVue.nextTick();
+      await localVue.nextTick();
+      expect(wrapper.vm.model).not.toEqual(initialModel);
+      expect(wrapper.vm.defaults).not.toEqual(initialDefaults);
+      expect(wrapper.vm.cache).not.toEqual(initialCache);
+    });
+
+  /**
+   * Core UI Tests
+   */
+
+  test('renders correct number of fields when model selection changes',
+    async () => {
+      let fields = wrapper.findAllComponents({ name: 'DoubleField' });
+      expect(fields).toHaveLength(Object.keys(wrapper.vm.cache.Tinker10).length);
+      wrapper.vm.model.bias_model = 'Tinker10PBSplit';
+      await localVue.nextTick();
+      await localVue.nextTick();
+      fields = wrapper.findAllComponents({ name: 'DoubleField' });
+      expect(fields).toHaveLength(Object.keys(wrapper.vm.cache.Tinker10PBSplit).length);
+    });
+
+  test('renders correct values and names for fields even when model selection changes',
+    async () => {
+      let params = Object.entries(wrapper.vm.model.bias_params);
+      params.forEach(([key, value], _) => {
+        expect(wrapper.html()).toEqual(expect.stringMatching(new RegExp(`.*${key}.*`)));
+        expect(wrapper.html()).toEqual(expect.stringMatching(new RegExp(`.*${value}.*`)));
+      });
+      wrapper.vm.model.bias_model = 'Tinker10PBSplit';
+      await localVue.nextTick();
+      await localVue.nextTick();
+      params = Object.entries(wrapper.vm.model.bias_params);
+      params.forEach(([key, value], _) => {
+        expect(wrapper.html()).toEqual(expect.stringMatching(new RegExp(`.*${key}.*`)));
+        expect(wrapper.html()).toEqual(expect.stringMatching(new RegExp(`.*${value}.*`)));
+      });
+    });
+
+  test('renders correct title based on props',
+    async () => {
+      expect(wrapper.html()).toEqual(expect.stringMatching(new RegExp('.*Bias.*')));
+      wrapper.setProps({
+        ...wrapper.vm.propsData,
+        title: 'Another Model',
+      });
+      await localVue.nextTick();
+      await localVue.nextTick();
+      expect(wrapper.html()).toEqual(expect.stringMatching(new RegExp('.*Another Model.*')));
+    });
+});

--- a/client/tests/unit/GenericForm.spec.js
+++ b/client/tests/unit/GenericForm.spec.js
@@ -111,7 +111,7 @@ describe('Mounted GenericForm', () => {
   test('renders correct values and names for fields even when model selection changes',
     async () => {
       let params = Object.entries(wrapper.vm.model.bias_params);
-      params.forEach(([key, value], _) => {
+      params.forEach(([key, value]) => {
         expect(wrapper.html()).toEqual(expect.stringMatching(new RegExp(`.*${key}.*`)));
         expect(wrapper.html()).toEqual(expect.stringMatching(new RegExp(`.*${value}.*`)));
       });
@@ -119,7 +119,7 @@ describe('Mounted GenericForm', () => {
       await localVue.nextTick();
       await localVue.nextTick();
       params = Object.entries(wrapper.vm.model.bias_params);
-      params.forEach(([key, value], _) => {
+      params.forEach(([key, value]) => {
         expect(wrapper.html()).toEqual(expect.stringMatching(new RegExp(`.*${key}.*`)));
         expect(wrapper.html()).toEqual(expect.stringMatching(new RegExp(`.*${value}.*`)));
       });


### PR DESCRIPTION
### Overview
This is a pull request to finish off US279, which was focused on getting a GenericForm template going to simplify long-term maintenance of our forms.

It includes eight tests, which all used the 'Bias' form's metadata as a base:
- check to verify component data is initialized correctly
- check to verify cache is updated correctly when model selection changes
- check to verify available parameters change when model selection changes
- check to verify an onChange event is emitted whenever model selection or params have changed
- check to verify that component data reflects changes in its initial_state prop
- check to verify that the component renders the correct number of fields when model selection changes
- check to verify that correct values and names for each field are rendered in the resultant HTML
- check to verify that the correct title is rendered in the resultant HTML

### Includes:
- Tests are in tests/unit/GenericForm.spec.js
- jest.config.js was adjusted to except the GenericForm tests in the tests it currently excludes
- @/constants/forms.js' top level data structure was changed from an array to an object to help with testing
- @/components/forms/index.js had minor changes to support the above

### Developer Checklist:
- [X] The code follows the Quality Policy file on Google Drive
- [X] My code has been developer-tested and includes unit tests
- [X] I have considered proper use of exceptions
- [X] I have eliminated IDE warnings
- [X] I have included tasks associated with this pull request in the Sprint Progress Sheet.

### Notes:
- This is being merged into GenericForms again so that it doesn't interfere with the current user experience of dev.
- Why just the Bias form context? Hypothetically, since this component is being used for EVERY basic form, verifying that ONE of them works correctly is enough. I chose Bias because of familiarity but this choice is arbitrary.
- I did try to make more generic tests work (kind of like integration.spec.js does on dev) but left it behind as the amount of hardcoded sample data required to make it work ballooned. This is probably an user story in and of itself and seems beyond the scope of this one.
- The current tests don't check for the exceptions (checkbox for one value of a particular model of our profile forms and a dropdown for one value for a particular model of concentration form). I think these are high effort & low value at this point and since GenericForm is likely to change a lot next Sprint as we include the more advanced forms it makes sense to me to hold off on it for now.