### PR TITLE
U339 Reject Same-Name Models

### DIFF
--- a/client/.eslintrc.js
+++ b/client/.eslintrc.js
@@ -29,6 +29,7 @@ module.exports = {
      * have a leading underscore.
      */
     'no-underscore-dangle': [0],
+    'no-irregular-whitespace': [0],
   },
   overrides: [
     {

--- a/client/src/components/Models/Model.vue
+++ b/client/src/components/Models/Model.vue
@@ -15,7 +15,7 @@
       <span id="error">{{ invalidName ? 'Name is already in use' : '⠀'}}</span>
     </div>
 
-    <div v-if="editing">
+    <div v-if="editing" id="model-buttons">
       <md-button
         class="md-icon-button"
         @click="reset">
@@ -30,7 +30,7 @@
         <md-tooltip>Confirm</md-tooltip>
       </md-button>
     </div>
-    <div v-else>
+    <div v-else id="model-buttons">
       <md-button
         class="md-icon-button"
         @click="$emit('edit-click', name)"
@@ -123,6 +123,9 @@ export default {
     display: flex;
     flex-direction: row;
     align-items: center;
+  }
+  #model-buttons {
+    padding-bottom: 15px;
   }
   #error {
     color: red;

--- a/client/src/components/Models/Model.vue
+++ b/client/src/components/Models/Model.vue
@@ -1,13 +1,18 @@
 <template>
   <md-list-item>
     <div class="md-list-item-text">
-      <md-field>
+      <md-field :class="validationClass">
         <md-input
           @mousedown="(e) => blocked && !editing ? e.preventDefault() : null"
           @focus.native="editMode"
           :value="localName"
           v-model="localName"/>
       </md-field>
+      <!--
+        The whitespace character on the next line isn't a space.
+        It's used as a workaround to render something for formatting.
+       -->
+      <span id="error">{{ invalidName ? 'Name is already in use' : '⠀'}}</span>
     </div>
 
     <div v-if="editing">
@@ -19,6 +24,7 @@
       </md-button>
       <md-button
         class="md-icon-button"
+        :disabled="invalidName"
         @click="localName === name ? reset() : submit()">
         <md-icon>done</md-icon>
         <md-tooltip>Confirm</md-tooltip>
@@ -71,6 +77,14 @@ export default {
       editing: false,
     };
   },
+  computed: {
+    invalidName() {
+      const invalid = this.$store.state.modelNames.includes(this.localName.trim())
+                      && this.localName.trim() !== this.name;
+      return invalid;
+    },
+    validationClass() { return { 'md-invalid': this.invalidName }; },
+  },
   methods: {
     reset() {
       this.editing = false;
@@ -84,6 +98,7 @@ export default {
     },
     submit() {
       this.editing = false;
+      this.localName = this.localName.trim();
       this.$emit('rename-click', this.localName);
       this.$emit('release');
     },
@@ -98,11 +113,19 @@ export default {
   .md-field:after {
     height: 0px
   }
+  .md-list-item {
+    display: flex;
+  }
   .md-field {
     margin: 0px 0px 0px 0px;
+    height: '100%';
     padding: 0;
     display: flex;
     flex-direction: row;
     align-items: center;
+  }
+  #error {
+    color: red;
+    font-size: small;
   }
 </style>

--- a/client/src/components/Models/index.vue
+++ b/client/src/components/Models/index.vue
@@ -134,6 +134,7 @@ export default {
     width: 100%;
     margin-bottom: 16px;
     margin-top: 16px;
+    padding-top: 32px;
     height: ''
   }
 </style>

--- a/client/src/components/Models/index.vue
+++ b/client/src/components/Models/index.vue
@@ -22,7 +22,7 @@
           </md-button>
         </div>
       </div>
-      <md-list v-if="STORE_STATE.modelNames.length > 0" class="model-list">
+      <md-list v-if="STORE_STATE.modelNames.length > 0" class="model-list md-double-line">
         <Model
           v-for="modelName in STORE_STATE.modelNames"
           :key="modelName"
@@ -133,5 +133,7 @@ export default {
   .model-list {
     width: 100%;
     margin-bottom: 16px;
+    margin-top: 16px;
+    height: ''
   }
 </style>

--- a/client/src/views/Forms.vue
+++ b/client/src/views/Forms.vue
@@ -33,13 +33,14 @@
     <md-dialog :md-active.sync="showSaveDialog" v-else  @keyup.enter="save">
       <md-dialog-title>Save Model</md-dialog-title>
       <md-dialog-content>
-        <md-field>
+        <md-field :class="validationClass">
           <label>Model Name</label>
           <md-input ref="saveInput" v-model="name" :value="name"/>
+          <div class="md-error" v-if="invalidName">Name is already in use.</div>
         </md-field>
       </md-dialog-content>
       <md-dialog-actions>
-        <md-button @click="save">Save Model (Enter)</md-button>
+        <md-button :disabled="invalidName" @click="save">Save Model (Enter)</md-button>
         <md-button @click="showSaveDialog = false">Cancel</md-button>
       </md-dialog-actions>
     </md-dialog>
@@ -128,6 +129,14 @@ export default {
   updated() {
     this.scrollToAnchor();
   },
+  computed: {
+    invalidName() {
+      const invalid = this.$store.state.modelNames
+        .includes(this.name ? this.name.trim() : undefined);
+      return invalid;
+    },
+    validationClass() { return { 'md-invalid': this.invalidName }; },
+  },
   methods: {
     scrollToAnchor() {
       this.$nextTick(() => {
@@ -145,6 +154,7 @@ export default {
       this.$router.push('/');
     },
     async save() {
+      if (this.invalidName) return;
       this.loading = true;
       if (this.edit) {
         await this.$store.updateModel(this.name, this.currentFormState);


### PR DESCRIPTION
### Overview
This implements a 'name in use' validation check for names in the model list & in the create dialog. The check in the model list was a bit quirky and I had to create my own error component instead of leaning on md-field's to avoid issues with the error being hidden by other components (yes, I did tinker with z-values and a number of other solutions before deciding to go this route). This meant making each item in the list a double item so that it could have subtext.

### Includes:
Check files changed.

### Developer Checklist:
- [X] The code follows the Quality Policy file on Google Drive
- [X] My code has been developer-tested and includes unit tests
- [X] I have considered proper use of exceptions
- [X] I have eliminated IDE warnings

### Notes:
- Might be worth introducing some other validation checks (no special characters, no empty field, etc...) but could let Steven do this to get him familiar