### PR TITLE
Add default tracer halo model

### DIFF
--- a/server/halomod_app/endpoint_model.py
+++ b/server/halomod_app/endpoint_model.py
@@ -7,6 +7,7 @@ from flask_cors import CORS
 from flask import Flask, jsonify, request, session, abort, send_file
 from . import utils
 from .utils import get_model_names
+from halomod import TracerHaloModel
 import base64
 import json
 import dill as pickle
@@ -16,7 +17,7 @@ import numpy as np
 
 
 endpoint_model = Blueprint('endpoint_model', __name__)
-
+initial_model = TracerHaloModel(rmax=150, rnum=200, transfer_params={"kmax":1e3, 'extrapolate_with_eh': True})
 
 """Create a new model
 POST /model
@@ -45,7 +46,7 @@ def create():
     else:
         models = {}
 
-    models[label] = utils.hmf_driver(**params)  # creates model from params
+    models[label] = utils.hmf_driver(previous=initial_model, **params)  # creates model from params
     session["models"] = pickle.dumps(models)  # writes updated model dict to session
 
     # returns new list of model names


### PR DESCRIPTION
### Overview
This PR implements a change to include a precomputed default Tracer Halo Model on the server, as detailed in #139 that is passed as the `hmf-driver`'s `previous` parameter in the create `/model` endpoint. The default model is based on the following parameters:
```python
TracerHaloModel(rmax=150, rnum=200, transfer_params={"kmax":1e3, 'extrapolate_with_eh': True})
```

### Includes:
- server\halomod_app\endpoint_model.py

### Developer Checklist:
- [x] The code follows the Quality Policy file on Google Drive
- [x] My code has been developer-tested and includes unit tests
- [x] I have considered proper use of exceptions
- [x] I have eliminated IDE warnings
- [x] I have included tasks associated with this pull request in the Sprint Progress Sheet.

### Notes:
Steven has articulated that any new models that are cloned from this initial model that alter the cosmology parameters shouldn't use the same parameters as the default model, as the calculation would take too long. This additional constraint/consideration is outside the scope of this one-point user story, so it is *not*  implemented. A new GitHub issue should be created to address this in the future. 

### Refs:
- https://the-halo-mod.atlassian.net/browse/HM-340