### PR TITLE
I100 Model Naming

### DIFF
--- a/.github/workflows/server.yaml
+++ b/.github/workflows/server.yaml
@@ -45,7 +45,7 @@ jobs:
       with:
         path: ~/.cache/pip
         # Makes the hashing depend on changes to requirements.txt and python version
-        key: ${{ hashFiles('server/requirements.txt') }} py3.9.5
+        key: ${{ runner.os }}-${{ hashFiles('server/requirements.txt') }}-py3.9.5
     
     - name: Set up Python 3.9.5
       uses: actions/setup-python@v2

--- a/.gitignore
+++ b/.gitignore
@@ -339,6 +339,9 @@ dist
 # TODO: where does this rule come from?
 docs/_book
 
+# For local testing
+client/vue.config.js
+
 # TODO: where does this rule come from?
 test/
 

--- a/client/src/components/DoubleField.vue
+++ b/client/src/components/DoubleField.vue
@@ -34,22 +34,21 @@ export default {
   data() {
     return {
       current: this.init,
+      isValid: true,
     };
   },
   computed: {
     isBetween() { return between(this.current, this.min, this.max); },
     isNumeric() { return numeric(this.current); },
     isDefined() { return defined(this.current); },
-    isValid() {
-      const valid = this.isDefined && this.isNumeric && this.isBetween;
-      this.$emit('is-valid', valid);
-      return valid;
-    },
     validationClass() { return { 'md-invalid': !this.isValid }; },
   },
   watch: {
     current() {
-      if (this.isValid) {
+      const valid = this.isDefined && this.isNumeric && this.isBetween;
+      this.$emit('is-valid', valid);
+      this.isValid = valid;
+      if (valid) {
         this.$emit('input', Number(this.current));
       }
     },

--- a/client/src/components/Forms/GenericForm.vue
+++ b/client/src/components/Forms/GenericForm.vue
@@ -253,7 +253,6 @@ export default {
         let parameterIndex = 0;
         while (!visibleParameterFound && parameterIndex < parameterKeys.length) {
           if (this.isVisible(parameterKeys[parameterIndex])) {
-            debug('Parameter ', parameterKeys[parameterIndex], ' is visible');
             visibleParameterFound = true;
           }
           parameterIndex += 1;
@@ -288,7 +287,6 @@ export default {
      * Used to find the model name of the currently selected model.
      */
     getKeyByValue(object, value) {
-      debug('getKeyByValue ran');
       return Object.keys(object).find((key) => object[key] === value);
     },
   },

--- a/client/src/components/Models/Model.vue
+++ b/client/src/components/Models/Model.vue
@@ -9,6 +9,7 @@
             :value="localName"
             v-model="localName"/>
         </md-field>
+        <md-tooltip v-if="!editing">Click or tap to edit model name</md-tooltip>
       </div>
       <md-icon v-if="invalidName" class="md-accent">warning
         <md-tooltip :md-active.sync="invalidName">Name is already in use</md-tooltip>

--- a/client/src/components/Models/Model.vue
+++ b/client/src/components/Models/Model.vue
@@ -2,7 +2,7 @@
   <div>
     <md-list-item>
       <div class="md-list-item-text">
-        <md-field class="renameField">
+        <md-field :class="`renameField ${validationClass}`">
           <md-input
             @mousedown="(e) => blocked && !editing ? e.preventDefault() : null"
             @focus.native="editMode"
@@ -10,6 +10,9 @@
             v-model="localName"/>
         </md-field>
       </div>
+      <md-icon v-if="invalidName" class="md-accent">warning
+        <md-tooltip :md-active.sync="invalidName">Name is already in use</md-tooltip>
+      </md-icon>
 
       <div v-if="editing">
         <md-button

--- a/client/src/components/Models/Model.vue
+++ b/client/src/components/Models/Model.vue
@@ -12,7 +12,7 @@
         <md-tooltip v-if="!editing">Click or tap to edit model name</md-tooltip>
       </div>
       <md-icon v-if="invalidName" class="md-accent">warning
-        <md-tooltip :md-active.sync="invalidName">Name is already in use</md-tooltip>
+        <md-tooltip :md-active="invalidName">Name is already in use</md-tooltip>
       </md-icon>
 
       <div v-if="editing">
@@ -24,7 +24,8 @@
         </md-button>
         <md-button
           class="md-icon-button"
-          @click="localName === name ? reset() : submit()">
+          @click="localName === name ? reset() : submit()"
+          :disabled="invalidName">
           <md-icon>done</md-icon>
           <md-tooltip>Confirm</md-tooltip>
         </md-button>

--- a/client/src/components/Models/index.vue
+++ b/client/src/components/Models/index.vue
@@ -14,10 +14,6 @@
           </div>
         </div>
         <div class="md-toolbar-section-end">
-          <!-- At this moment, restarting causes some inconsistencies between
-          the state held on the server and the state in the browser.
-          <md-button @click="restart" class="md-accent">Restart</md-button>
-          -->
             <md-button @click="create" class="md-icon-button">
               <md-icon>add</md-icon>
               <md-tooltip>New Model</md-tooltip>
@@ -156,7 +152,6 @@ export default {
   width: 100%;
   margin-bottom: 16px;
   margin-top: 16px;
-  padding-top: 32px;
   height: '';
 }
 .tooltip {

--- a/client/src/utils/Store.js
+++ b/client/src/utils/Store.js
@@ -260,8 +260,8 @@ export default class Store {
   /**
    * Updates a model.
    *
-   * @param {object} model the updated model object
    * @param {string} name the name of the model to update
+   * @param {object} model the updated model object
    */
   updateModel = async (name, model) => {
     try {

--- a/client/src/views/Forms.vue
+++ b/client/src/views/Forms.vue
@@ -13,8 +13,7 @@
     :modelName="name"
     @onChange="(data) => currentFormState = data" v-if="initialFormState"
     @is-valid="isValid"
-    @activate-save="activateSaveDialog"
-    @name-changed="updateName"/>
+    @activate-save="activateSaveDialog"/>
   <div id="float">
     <md-button @click="showCancelDialog = true" class="md-raised">Cancel</md-button>
     <div style="display: inline-block">
@@ -187,6 +186,12 @@ export default {
     async save() {
       if (this.edit) {
         this.loading = true;
+
+        // Check to see if the name was changed
+        if (this.name !== this.$route.params.id) {
+          await this.$store.renameModel(this.$route.params.id, this.name);
+        }
+
         await this.$store.updateModel(this.name, this.currentFormState);
       } else {
         if (this.invalidName) return;


### PR DESCRIPTION
## Overview
This PR resolves #100 and resolves #121 by implementing a few visual additions and also adding a way to rename models within the `Forms` component without hitting "Enter" first.

### Renaming models within `Forms` component

The new way to rename models within the `Forms` component looks like so:

![image](https://user-images.githubusercontent.com/17774559/121787252-e2b62000-cb79-11eb-9ba9-8f1ec96c58a8.png)

which also gives the same type of error info when a model already has the name chosen, and it disables the "Save" button when it is incorrect.

![image](https://user-images.githubusercontent.com/17774559/121787276-08dbc000-cb7a-11eb-878b-878145ee125d.png)

It also does this when creating a form:

![image](https://user-images.githubusercontent.com/17774559/121787307-37f23180-cb7a-11eb-8fd6-41e90880374f.png)

### Renaming models from main page

There is now a tooltip that shows up when you hover over a model name that says that the model name can be edited by clicking on it there:

<image src="https://user-images.githubusercontent.com/17774559/121787367-856e9e80-cb7a-11eb-943b-f70cc55364b0.png" width=500 />

In addition, as you can see above, the model names are centered again. One other change is when a model name is incorrect, instead of having text come up at the bottom (causing issues with the text moving around) it comes up on the side with a very visible icon:

<image src="https://user-images.githubusercontent.com/17774559/121787536-6d4b4f00-cb7b-11eb-9d92-a076fa144995.png" width=500 />

## Includes:
- .gitignore 
- client/src/components/DoubleField.vue 
- client/src/components/Forms/GenericForm.vue 
- client/src/components/Forms/index.vue 
- client/src/components/Models/Model.vue 
- client/src/components/Models/index.vue 
- client/src/utils/Store.js 
- client/src/views/Forms.vue 

## Developer Checklist:
- [ ] My code has been developer-tested and includes unit tests - It has been tested manually but does not have unit tests.
- [x] I have considered proper use of exceptions
- [x] I have eliminated IDE warnings

## Notes:
- Updating how `DoubleField` handles validation solved a whole lot of issues. That one thing seemed to improve performance by about 2-3x.
- Made validation testing in other places more efficient.